### PR TITLE
Change to lazy array JIT.

### DIFF
--- a/app/controllers/lazy-loaded-loans.js
+++ b/app/controllers/lazy-loaded-loans.js
@@ -35,13 +35,12 @@ export default Ember.Controller.extend({
 
   model: function () {
     var self = this;
-    var pageIndex = 0;
     var totalCount = this.get('totalCount');
     return LazyArray.create({
+      chunkSize: 50,
       totalCount: totalCount,
-      callback: function () {
-        pageIndex ++;
-        return self.store.find('loan', {page: pageIndex}).then(function (data) {
+      callback: function (pageIndex) {
+        return self.store.find('loan', {page: pageIndex + 1}).then(function (data) {
           return data.get('content');
         });
       }


### PR DESCRIPTION
We updated lazy-array on ember-table-addon to fix some problem and made lazy-array much like ember-table's ajax-lazy-load. And we exposed "ChunkSize" used by lazy-array, may be this way is right? 