### PR TITLE
Finish webdriver test cases for "grouping column with default indicator"

### DIFF
--- a/python-webdriver-tests/features/06_grouped_rows.feature
+++ b/python-webdriver-tests/features/06_grouped_rows.feature
@@ -31,13 +31,28 @@ Feature: Indicators for expanding and collapsing grouped rows
       | +         | group4     | f4    | s4     |
       | +         | group5     | f5    | s5     |
 
-  @wip
+  @complete
   Scenario: Default expansion indicator with fully loaded data
-    Given There are 50 grouped loans
+    Given There are 5 grouped loans
     When Presenting "grouping column"
-    Then The row "row_parent" indicator should be "expand"
-    When Click "expand" for row "row_parent"
-    Then The row "row_parent" indicator should be "collapse"
+    Then The row "Group 0" indicator should be "expand"
+    Then The row "Group 1" indicator should be "expand"
+    Then The row "Group 2" indicator should be "expand"
+    Then The row "Group 3" indicator should be "expand"
+    Then The row "Group 4" indicator should be "expand"
+    When Click "expand" for row "Group 1"
+    Then The row "Group 1" indicator should be "collapse"
+    When Click "collapse" for row "Group 1"
+    Then The row "Group 1" indicator should be "expand"
+
+  @complete
+  Scenario: The grouping column should not be scrolled
+    Given There are 5 grouped loans
+    When Presenting "grouping column"
+    When The user drags the "status" on column to "right" with 1000 pixel
+    And Drag horizontal scroll bar with 1000 pixel
+    Then The column header block should has "scroll left" and same as body scroll left
+    And The "GroupingColumn" should not be scrolled
 
 
   @wip

--- a/python-webdriver-tests/features/steps.py
+++ b/python-webdriver-tests/features/steps.py
@@ -512,7 +512,10 @@ def check_row_indicator(step, row_name, indicator):
     with AssertContextManager(step):
         row = world.browser.execute_script(
             "return $('.ember-table-content:contains(" + str(row_name) + ")').siblings()")
-        assert_true(step, str(indicator), row[0].get_attribute("class"))
+        if indicator == "expand":
+            assert_true(step, "unfold" not in row[0].get_attribute("class"))
+        else:
+            assert_true(step, "unfold" in row[0].get_attribute("class"))
 
 
 @step('There are (\d+) grouped loans$')
@@ -520,3 +523,17 @@ def prepare_grouping_loans(step, count):
     with AssertContextManager(step):
         prepare_grouping_data(count)
 
+
+@step('The "(.*?)" should not be scrolled$')
+def check_grouping_column_should_not_scroll(step, column_name):
+    with AssertContextManager(step):
+        columns = world.browser.execute_script(
+            "return $('.ember-table-header-container .ember-table-content').parent().parent()")
+        for index, col in enumerate(columns):
+            name = world.browser.execute_script(
+                "return $('.ember-table-header-container .ember-table-content:eq(" + str(index) + ")').text().trim()")
+            if name == column_name:
+                num = index
+        grouping_column_scroll_left = world.browser.execute_script(
+            "return $('.lazy-list-container:eq(" + str(num) + ")').scrollLeft()")
+        assert_true(step, int(grouping_column_scroll_left) == 0)


### PR DESCRIPTION
1. Finish webdriver test cases for "grouping column with default indicator"
2. Finish webdriver test cases for "grouping column should not be scrolled when drag scroll bar for common columns"