### PR TITLE
Add webdriver test cases for "expand/collapse unlimited level of grouping column".

### DIFF
--- a/python-webdriver-tests/features/06_grouped_rows.feature
+++ b/python-webdriver-tests/features/06_grouped_rows.feature
@@ -50,7 +50,7 @@ Feature: Indicators for expanding and collapsing grouped rows
     And The user drags the "status" on column to "right" with 1000 pixel
     And Drag horizontal scroll bar with 1000 pixel
     Then The column header block should has "scroll left" and same as body scroll left
-    And The "GroupingColumn" should not be scrolled
+    And The grouping and fixed columns should not be scrolled
 
 
   @complete
@@ -72,12 +72,12 @@ Feature: Indicators for expanding and collapsing grouped rows
     Then I see grouped rows:
       | indicator | groupName   | Id   | Activity |
       | -         | group1      | f1   | s1       |
-      | +         | group1-chd1 | f1-1 | s1-1     |
-      | +         | group1-chd2 | f1-2 | s1-2     |
+      |           | group1-chd1 | f1-1 | s1-1     |
+      |           | group1-chd2 | f1-2 | s1-2     |
       | +         | group2      | f2   | s2       |
       | -         | group3      | f3   | s3       |
-      | +         | group3-chd1 | f3-1 | s3-1     |
-      | +         | group3-chd2 | f3-2 | s3-2     |
+      |           | group3-chd1 | f3-1 | s3-1     |
+      |           | group3-chd2 | f3-2 | s3-2     |
       | +         | group4      | f4   | s4       |
       | +         | group5      | f5   | s5       |
     When Click "collapse" for row "group1"
@@ -86,8 +86,8 @@ Feature: Indicators for expanding and collapsing grouped rows
       | +         | group1      | f1   | s1       |
       | +         | group2      | f2   | s2       |
       | -         | group3      | f3   | s3       |
-      | +         | group3-chd1 | f3-1 | s3-1     |
-      | +         | group3-chd2 | f3-2 | s3-2     |
+      |           | group3-chd1 | f3-1 | s3-1     |
+      |           | group3-chd2 | f3-2 | s3-2     |
       | +         | group4      | f4   | s4       |
       | +         | group5      | f5   | s5       |
 
@@ -137,11 +137,11 @@ Feature: Indicators for expanding and collapsing grouped rows
       | indicator | groupName        | Id     | Activity |
       | -         | group1           | f1     | s1       |
       | -         | group1-chd1      | f1-1   | s1-1     |
-      | +         | group1-chd1-chd1 | f1-1-1 | s1-1-1   |
-      | +         | group1-chd1-chd2 | f1-1-2 | s1-1-2   |
+      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1   |
+      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2   |
       | -         | group1-chd2      | f1-2   | s1-2     |
-      | +         | group1-chd2-chd1 | f1-2-1 | s1-2-1   |
-      | +         | group1-chd2-chd2 | f1-2-2 | s1-2-2   |
+      |           | group1-chd2-chd1 | f1-2-1 | s1-2-1   |
+      |           | group1-chd2-chd2 | f1-2-2 | s1-2-2   |
       | +         | group2           | f2     | s2       |
     When Click "collapse" for row "group1"
     Then I see grouped rows:
@@ -153,11 +153,11 @@ Feature: Indicators for expanding and collapsing grouped rows
       | indicator | groupName        | Id     | Activity |
       | -         | group1           | f1     | s1       |
       | -         | group1-chd1      | f1-1   | s1-1     |
-      | +         | group1-chd1-chd1 | f1-1-1 | s1-1-1   |
-      | +         | group1-chd1-chd2 | f1-1-2 | s1-1-2   |
+      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1   |
+      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2   |
       | -         | group1-chd2      | f1-2   | s1-2     |
-      | +         | group1-chd2-chd1 | f1-2-1 | s1-2-1   |
-      | +         | group1-chd2-chd2 | f1-2-2 | s1-2-2   |
+      |           | group1-chd2-chd1 | f1-2-1 | s1-2-1   |
+      |           | group1-chd2-chd2 | f1-2-2 | s1-2-2   |
       | +         | group2           | f2     | s2       |
 
   @wip
@@ -200,7 +200,7 @@ Feature: Indicators for expanding and collapsing grouped rows
       | >         | group4      | f4    | s4     |
       | >         | group5      | f5    | s5     |
 
-  @wip
+  @complete
   Scenario: The grouping column should be auto resize
     Given I have the following grouped loans in MounteBank:
       | groupName        | id     | activity | isGroupRow |
@@ -212,18 +212,38 @@ Feature: Indicators for expanding and collapsing grouped rows
       | group1-chd2-chd1 | f1-2-1 | s1-2-1   | False      |
       | group1-chd2-chd2 | f1-2-2 | s1-2-2   | False      |
       | group2           | f2     | s2       | True       |
-      | group3           | f3     | s3       | True       |
-      | group3-chd1      | f3-1   | s3-1     | False      |
-      | group3-chd2      | f3-2   | s3-2     | False      |
-      | group4           | f4     | s4       | True       |
-      | group5           | f5     | s5       | True       |
+      | group2-chd1      | f2-1   | s2-1     | True       |
+      | group2-chd1-chd1 | f2-1-1 | s2-1-1   | False      |
+      | group2-chd1-chd2 | f2-1-2 | s2-1-2   | False      |
+      | group2-chd2      | f2-2   | s2-2     | True       |
+      | group2-chd2-chd1 | f2-2-1 | s2-2-1   | False      |
+      | group2-chd2-chd2 | f2-2-2 | s2-2-2   | False      |
     When Presenting "grouping column"
-    Then The "GroupingColumn" column width should be 150 pixel
+    Then The "GroupingColumn" column width should be 149 pixel
     When Click "expand" for row "group1"
-    Then The "GroupingColumn" column width should be 170 pixel
-    When Click "expand" for row "group-chd1"
-    Then The "GroupingColumn" column width should be 190 pixel
-
+    Then The "GroupingColumn" column width should be 159 pixel
+    When Click "expand" for row "group1-chd1"
+    Then The "GroupingColumn" column width should be 169 pixel
+    When Click "expand" for row "group1-chd2"
+    Then The "GroupingColumn" column width should be 169 pixel
+    When Click "expand" for row "group2"
+    Then The "GroupingColumn" column width should be 169 pixel
+#    When Click "collapse" for row "group1"
+#    Then The "GroupingColumn" column width should be 159 pixel
+#    When Click "collapse" for row "group2"
+#    Then The "GroupingColumn" column width should be 149 pixel
+#    When Click "expand" for row "group1"
+#    Then The "GroupingColumn" column width should be 169 pixel
+#    When Click "collapse" for row "group1-chd1"
+#    Then The "GroupingColumn" column width should be 159 pixel
+#    When Click "expand" for row "group2"
+#    Then The "GroupingColumn" column width should be 159 pixel
+#    When Click "collapse" for row "group1-chd2"
+#    Then The "GroupingColumn" column width should be 159 pixel
+#    When Click "collapse" for row "group1"
+#    Then The "GroupingColumn" column width should be 159 pixel
+#    When Click "collapse" for row "group2"
+#    Then The "GroupingColumn" column width should be 149 pixel
 
   @wip
   Scenario: Expand grouped row with partial loaded

--- a/python-webdriver-tests/features/steps.py
+++ b/python-webdriver-tests/features/steps.py
@@ -277,7 +277,8 @@ def drag_column_with_pixel(step, column_name, left_or_right, offsetx):
     with AssertContextManager(step):
         if str(column_name) == "GroupingColumn":
             bo.resize_column_by_index(world.browser, 0, left_or_right, offsetx)
-        bo.resize_column(world.browser, column_name, left_or_right, offsetx)
+        else:
+            bo.resize_column(world.browser, column_name, left_or_right, offsetx)
 
 
 @step('Reorder an inner column "(.*?)" header to "(.*?)" with (\d+) pixel')
@@ -285,7 +286,8 @@ def reorder_column_with_pixel(step, column_name, left_or_right, offsetx):
     with AssertContextManager(step):
         if str(column_name) == "GroupingColumn":
             bo.reorder_column_by_index(world.browser, 0, left_or_right, offsetx)
-        bo.reorder_column(world.browser, column_name, left_or_right, offsetx)
+        else:
+            bo.reorder_column(world.browser, column_name, left_or_right, offsetx)
 
 
 @step('The reorder indicator line should be (\d+) from left$')
@@ -323,7 +325,10 @@ def check_column_width(step, column_name, pixel):
 @step('The index (\d+) should be "(.*?)" column$')
 def check_reorder_column(step, index, name):
     with AssertContextManager(step):
-        assert_true(step, bo.get_col_name_by_index(world.browser, index) == name)
+        if name == "GroupingColumn":
+            assert_true(step, bo.get_col_name_by_index(world.browser, index) == "")
+        else:
+            assert_true(step, bo.get_col_name_by_index(world.browser, index) == name)
 
 
 @step('The "(.*?)" column sort indicator should be "(.*?)"$')
@@ -357,6 +362,8 @@ def verify_grouped_row(index, row):
         assert_true(step, is_the_row_expanded(index))
     elif indicator == '+':
         assert_true(step, not is_the_row_expanded(index))
+    elif indicator == '':
+        assert_true(step, is_the_leaf_node(index))
 
     for field in row:
         if field != 'indicator':
@@ -365,11 +372,15 @@ def verify_grouped_row(index, row):
 
 def is_the_row_expanded(index):
     return world.browser.execute_script(
-        "return $('.ember-table-body-container "
-        ".ember-table-left-table-block "
-        ".ember-table-table-row:eq(" + str(index) + ") "
-        ".ember-table-cell:eq(0) "
-        ".grouping-column-indicator').hasClass('unfold')")
+        "return $('.ember-table-body-container .ember-table-left-table-block .ember-table-table-row:eq(" + str(
+            index) + ") .ember-table-cell:eq(0) .grouping-column-indicator').hasClass('unfold')")
+
+
+def is_the_leaf_node(index):
+    length = world.browser.execute_script(
+        "return $('.ember-table-body-container .ember-table-left-table-block .ember-table-table-row:eq(" + str(
+            index) + ") .ember-table-cell:eq(0) .grouping-column-indicator:has(div)').length")
+    return int(length) == 0
 
 
 def verify_cell_content(row_index, name, value):


### PR DESCRIPTION
1. Finish webdriver test case for "Auto resize grouping column when expand/collapse".

2. Modify some webdriver test cases which caused that the leaf node has no indicator.