### PR TITLE
Add row loading indicator demo page

### DIFF
--- a/app/controllers/grouped-row-loading-indicator.js
+++ b/app/controllers/grouped-row-loading-indicator.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 import ColumnDefinition from 'ember-table/models/column-definition';
+import CustomRowLoadingIndicator from './../views/custom-row-loading-indicator';
+
 
 export default Ember.Controller.extend({
 
@@ -10,8 +12,8 @@ export default Ember.Controller.extend({
       ["GL Account Type", "glAccountType"],
       ["GL Account Code", "glAccountCode"],
       ["GL Account Description", "glAccountDescription"],
-      ["Beginning DR (Base)", "beginningDr"],
-      ["Beginning CR (Base)", "beginningCr"],
+      ["Beginning DR (Base)", "beginningDR"],
+      ["Beginning CR (Base)", "beginningCR"],
       ["Net Beginning (Base)", "netBeginning"],
       ["Activity DR (Base)", "activityDr"],
       ["Activity CR (Base)", "activityCr"],
@@ -29,6 +31,8 @@ export default Ember.Controller.extend({
       });
     });
   }.property(),
+
+  rowLoadingIndicatorView: CustomRowLoadingIndicator,
 
   groupingMetadata: ["", ""]
 

--- a/app/router.js
+++ b/app/router.js
@@ -16,4 +16,5 @@ export default Router.map(function() {
   this.route('groupedRows', {path: 'grouped-rows'});
   this.route('groupedRowsWithLevel', {path: 'grouped-rows-with-level'});
   this.route('chunkedGroupingRows', {path: 'chunked-grouping-rows'});
+  this.route('groupedRowLoadingIndicator', {path: 'grouped-row-loading-indicator'});
 });

--- a/app/routes/grouped-row-loading-indicator.js
+++ b/app/routes/grouped-row-loading-indicator.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: function () {
+    return [
+      {
+        id: 1,
+        isLoading: false,
+        children: [
+          {
+            id: 11,
+            isLoading: false,
+            children: [
+              {
+                id: 111,
+                isLoading: true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        id: 2,
+        isLoading: false,
+        children: [
+          {
+            id: 21,
+            isLoading: false,
+            children: [
+              {
+                id: 211,
+                isLoading: true
+              }
+            ]
+          }
+        ]
+      }
+    ];
+  }
+});

--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -47,17 +47,122 @@
   margin-left: 5px;
   width: 25px;
   height: 10px;
-  
+
   &.fold > span {
     transition: all .3s linear;
     display: inline-block;
     transform: rotate(0deg);
-  }  
+  }
 
 
   &.unfold > span {
     transition: all .3s linear;
     display: inline-block;
     transform: rotate(90deg);
+  }
+}
+
+/* Custom less style for 'custom-row-loading-indicator' */
+.custom-row-loading-indicator {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  vertical-align: bottom;
+
+  &.loading {
+    display: block;
+  }
+}
+
+.box-shadow(@shadow) {
+  -webkit-box-shadow: @shadow;
+  -moz-box-shadow: @shadow;
+  box-shadow: @shadow;
+}
+
+.transition(@transition) {
+  -webkit-transition: @transition;
+  -moz-transition: @transition;
+  -o-transition: @transition;
+  transition: @transition;
+}
+
+.gradient-vertical(@start-color; @end-color; @start-percent: 0%; @end-percent: 100%) {
+  background-image: -webkit-linear-gradient(top, @start-color @start-percent, @end-color @end-percent);
+  background-image: linear-gradient(to bottom, @start-color @start-percent, @end-color @end-percent);
+}
+.gradient-striped(@color1; @color2; @angle: 45deg) {
+  background-image: -webkit-linear-gradient(
+    @angle,
+    @color1 30%,
+    @color2 30%,
+    @color2 33%,
+    transparent 33%,
+    transparent 46%,
+    @color2 46%,
+    @color2 50%,
+    @color1 50%,
+    @color1 80%,
+    @color2 80%,
+    @color2 83%,
+    transparent 83%,
+    transparent 97%,
+    @color2 97%,
+    @color2
+  );
+  background-image: linear-gradient(
+    @angle,
+    @color1 30%,
+    @color2 30%,
+    @color2 34%,
+    transparent 34%,
+    transparent 46%,
+    @color2 46%,
+    @color2 50%,
+    @color1 50%,
+    @color1 80%,
+    @color2 80%,
+    @color2 84%,
+    transparent 84%,
+    transparent 96%,
+    @color2 96%,
+    @color2
+  );
+}
+
+// ANIMATIONS
+@-webkit-keyframes progress-bar-animate {
+  from  { background-position: 40px 0; }
+  to    { background-position: 0 0; }
+}
+
+@keyframes progress-bar-animate {
+  from  { background-position: 40px 0; }
+  to    { background-position: 0 0; }
+}
+
+// outer container
+.progress {
+  overflow: hidden;
+  height: 100%;
+  .gradient-vertical(#ccc, #ddd);
+  .box-shadow(inset 0 1px 2px rgba(0,0,0,.1));
+
+  // inner progress bar
+  &-bar {
+    width: 0%;
+    height: 100%;
+    float: left;
+    box-sizing: border-box;
+    background-color: #79b;
+    background-size: 40px 40px;
+    .gradient-striped(rgba(255,255,255,0.2); rgba(0,0,0,0.1));
+    .box-shadow(inset 0 -1px 0 rgba(0,0,0,.1));
+    .transition(width 200ms ease);
+
+    -webkit-animation: progress-bar-animate 1s linear infinite;
+    animation: progress-bar-animate 1s linear infinite;
   }
 }

--- a/app/templates/custom-row-loading-indicator.hbs
+++ b/app/templates/custom-row-loading-indicator.hbs
@@ -1,0 +1,3 @@
+<div class="progress">
+    <div class="progress-bar" style="width: 100%;"></div>
+</div>

--- a/app/templates/grouped-row-loading-indicator.hbs
+++ b/app/templates/grouped-row-loading-indicator.hbs
@@ -1,0 +1,16 @@
+<h3 class="inline-header">Row Loading Indicator</h3>
+<h4>Grouping by:</h4>
+<ul>
+    <li>AccountType</li>
+    <li>AccountCode</li>
+</ul>
+<div class="lazy-loaded-table-container" style="height:200px;">
+  {{ember-table
+  hasFooter=false
+  enableContentSelection=true
+  content=model
+  groupingMetadata=groupingMetadata
+  rowLoadingIndicatorView=rowLoadingIndicatorView
+  columns=columns
+  }}
+</div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -9,4 +9,5 @@
     <li>{{#link-to 'groupedRows'}}Grouped rows{{/link-to}}</li>
     <li>{{#link-to 'groupedRowsWithLevel'}}Grouped rows with level{{/link-to}}</li>
     <li>{{#link-to 'chunkedGroupingRows'}}Chunked Grouping Rows{{/link-to}}</li>
+    <li>{{#link-to 'groupedRowLoadingIndicator'}}Rows with loading indicator{{/link-to}}</li>
 </ul>

--- a/app/views/custom-row-loading-indicator.js
+++ b/app/views/custom-row-loading-indicator.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+import RowLoadingIndicator from 'ember-table/views/row-loading-indicator';
+
+export default RowLoadingIndicator.extend({
+  templateName: 'custom-row-loading-indicator',
+
+  indicatorClass: Ember.computed(function() {
+    var classNames = ['custom-row-loading-indicator'];
+    if (this.get('isLoading')) {
+      classNames.push('loading');
+    }
+    return classNames.join(' ');
+  }).property('isLoading')
+});

--- a/python-webdriver-tests/features/basic_opr_module.py
+++ b/python-webdriver-tests/features/basic_opr_module.py
@@ -164,7 +164,7 @@ def sort_column(browser, col_name):
 def expand_collapse_row(browser, row_name):
     row = browser.execute_script(
         "return $('.ember-table-content:contains(" + str(row_name) + ")').siblings()")
-    row[0].click()
+    row[1].click()
 
 
 def command_ctrl_with_click(browser, col_name, command_or_ctrl):

--- a/python-webdriver-tests/features/steps.py
+++ b/python-webdriver-tests/features/steps.py
@@ -482,9 +482,9 @@ def check_row_indicator(step, row_name, indicator):
         row = world.browser.execute_script(
             "return $('.ember-table-content:contains(" + str(row_name) + ")').siblings()")
         if indicator == "expand":
-            assert_true(step, ("unfold" not in row[0].get_attribute("class")) and is_the_row_custom(row_name))
+            assert_true(step, ("unfold" not in row[1].get_attribute("class")) and is_the_row_custom(row_name))
         else:
-            assert_true(step, ("unfold" in row[0].get_attribute("class")) and is_the_row_custom(row_name))
+            assert_true(step, ("unfold" in row[1].get_attribute("class")) and is_the_row_custom(row_name))
 
 
 def is_the_row_custom(row_name):


### PR DESCRIPTION
Refactor demo page name to avoid name reflect

Can show demo page and show loading indicator all the time

Add custom-row-loading-indicator style

Update Webdriver test jquery selector index for indicator placeholder

Change custom-row-loading-indicator by pure CSS style