### PR TITLE
Add webdriver cases and make them as "work in progress" for "custom loading indicator", "default loading indicator" and other cases for lazily loaded in grouping column.

### DIFF
--- a/python-webdriver-tests/features/06_grouped_rows.feature
+++ b/python-webdriver-tests/features/06_grouped_rows.feature
@@ -80,16 +80,31 @@ Feature: Indicators for expanding and collapsing grouped rows
       | +         | group5      | f5   | s5       |
 
 
-  @test
+  @wip
   Scenario: Expand grouped row with partial loaded children loans
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
       | accountSection[20]-accountType[15]-accountCode[4] | f  | s                   |
-    When Presenting "grouping column present partial loaded children"
-    And The row "group1" indicator should be "expand"
+    And Presenting "grouping column present partial loaded children"
+    When Click "expand" for the 0 row
     Then There should be 2 sections loaded
-    When Customer drags scroll bar by offset 60 with 1 times
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[20]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click "expand" for the 0 row
+    When Click "expand" for the 1 row
     Then There should be 3 sections loaded
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[20]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click "expand" for the 0 row
+    And Click "expand" for the 1 row
+    When Customer drags scroll bar by offset 60 with 1 times
+    Then There should be 4 sections loaded
 
   @complete
   Scenario: Expand and collapse grouped rows with unlimited level
@@ -210,50 +225,71 @@ Feature: Indicators for expanding and collapsing grouped rows
 
   @wip
   Scenario: Expand grouped row with partial loaded
-    Given Given I have 200 grouped loans
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    Then There should be 1 sections loaded
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    When Customer drags scroll bar by offset 60 with 2 times
+    Then There should be 3 sections loaded
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    When Click "expand" for the 0 row
     Then There should be 2 sections loaded
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click "expand" for the 0 row
     When Customer drags scroll bar by offset 60 with 1 times
     Then There should be 3 sections loaded
 
+
   @wip
   Scenario: The default loading indicator should display when partial load grouped loans
-    Given I have 200 grouped loans
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Stop mountebank
     When Customer drags scroll bar by offset 60 with 1 times
-    Then The default loading indicator should display
+    Then The default loading indicator should display on 15 items
 
   @wip
   Scenario: The default loading indicator should display when partial load children loans
-    Given I have the following grouped loans in MounteBank:
-      | groupName | first | second |
-      | group1    | f1    | s1     |
-      | group2    | f2    | s2     |
-      | group3    | f3    | s3     |
-      | group4    | f4    | s4     |
-      | group5    | f5    | s5     |
-    When Presenting "grouping column present partial loaded children"
-    And The row "group1" indicator should be "expand"
-    When Customer drags scroll bar by offset 60 with 1 times
-    Then The default loading indicator should display
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click "expand" for the 0 row
+    And Stop mountebank
+    When Customer drags scroll bar by offset 20 with 1 times
+    Then The default loading indicator should display on 15 items
 
   @wip
   Scenario: The custom loading indicator should display when partial load grouped loans
-    Given I have 200 grouped loans
-    When Customer drags scroll bar by offset 60 with 1 times
-    Then The "custom" loading indicator should display
+    Given Presenting "grouping column with pluggable loading indicator"
+    When Click "expand" for the 0 row
+    And Click "expand" for the 1 row
+    Then The custom loading indicator should display on 15 items
 
   @wip
   Scenario: The default loading indicator should display when partial load children loans
-    Given I have the following grouped loans in MounteBank:
-      | groupName | first | second |
-      | group1    | f1    | s1     |
-      | group2    | f2    | s2     |
-      | group3    | f3    | s3     |
-      | group4    | f4    | s4     |
-      | group5    | f5    | s5     |
-    When Presenting "grouping column present partial loaded children"
-    And The row "group1" indicator should be "expand"
-    When Customer drags scroll bar by offset 60 with 1 times
-    Then The "custom" loading indicator should display
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                         | id | Beginning DR (Base) |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    When Click "expand" for the 0 row to check indicator
+    Then The default loading indicator should display on 15 items
 
   @complete
   Scenario: The grouping column should not be resizable and draggable

--- a/python-webdriver-tests/features/basic_opr_module.py
+++ b/python-webdriver-tests/features/basic_opr_module.py
@@ -3,6 +3,7 @@ from selenium.webdriver.common.keys import Keys
 __author__ = 'Liang Zhen'
 from selenium.webdriver import ActionChains
 import time
+import os
 
 
 def drag_scroll_by_css(browser, offsetx, offsety):
@@ -165,6 +166,19 @@ def expand_collapse_row(browser, row_name):
     row = browser.execute_script(
         "return $('.ember-table-content:contains(" + str(row_name) + ")').siblings()")
     row[1].click()
+
+
+def expand_collapse_row_by_index(browser, index):
+    row = browser.execute_script("return $('.grouping-column-indicator')")
+    row[int(index)].click()
+
+
+def stop_mb():
+    os.system("mb stop")
+
+
+def start_mb():
+    os.system('mb --allowCORS &')
 
 
 def command_ctrl_with_click(browser, col_name, command_or_ctrl):

--- a/python-webdriver-tests/features/steps.py
+++ b/python-webdriver-tests/features/steps.py
@@ -125,6 +125,7 @@ def list_all_loans(step, url):
             "grouping column": "http://localhost:4200/grouping-column",
             "grouping column with fixed columns": "http://localhost:4200/grouping-column-and-fixed",
             "grouping column with pluggable indicator": "http://localhost:4200/grouped-rows-with-level",
+            "grouping column with pluggable loading indicator": "http://localhost:4200/grouped-row-loading-indicator",
             "grouping column present partial loaded children": "http://localhost:4200/chunked-grouping-rows",
         }
         get_url(world.browser, options.get(url))
@@ -179,6 +180,7 @@ def check_loaded_chunk(step, num):
 
         assert_true(step, len(toJson) == 1)
         assert_true(step, toJson[0]['query']['section'] == "1")
+
 
 @step('There should be (\d+) sections loaded')
 def get_loaded_section(step, num):
@@ -456,6 +458,19 @@ def expand_collapse_row(step, expand_collapse, row_name):
         bo.expand_collapse_row(world.browser, row_name)
 
 
+@step('Click "(.*?)" for the (\d+) row to check indicator$')
+def expand_collapse_row(step, expand_collapse, index):
+    with AssertContextManager(step):
+        bo.stop_mb()
+        bo.expand_collapse_row_by_index(world.browser, index)
+
+
+@step('Click "(.*?)" for the (\d+) row$')
+def expand_collapse_row_by_index(step, expand_collapse, index):
+    with AssertContextManager(step):
+        bo.expand_collapse_row_by_index(world.browser, index)
+
+
 @step('Collapse all expanded rows')
 def collapse_expanded_rows(step):
     with AssertContextManager(step):
@@ -480,6 +495,33 @@ def check_row_indicator(step, row_name, indicator):
             assert_true(step, "unfold" not in row[1].get_attribute("class"))
         else:
             assert_true(step, "unfold" in row[1].get_attribute("class"))
+
+
+@step('Stop mountebank$')
+def stop_mb(step):
+    with AssertContextManager(step):
+        bo.stop_mb()
+
+
+@step('Start mountebank$')
+def start_mb(step):
+    with AssertContextManager(step):
+        bo.start_mb()
+
+
+@step('The default loading indicator should display on (\d+) items$')
+def check_default_loading_indicator(step, num):
+    with AssertContextManager(step):
+        indicator = world.browser.execute_script("return $('.row-loading-indicator.loading')")
+        assert_true(step, len(indicator) == int(num))
+        bo.start_mb()
+
+
+@step('The custom loading indicator should display on (\d+) items$')
+def check_costom_loading_indicator(step, num):
+    with AssertContextManager(step):
+        indicator = world.browser.execute_script("return $('.custom-row-loading-indicator.loading')")
+        assert_true(step, len(indicator) == int(num))
 
 
 @step('The row "(.*?)" indicator should be "(.*?)" with customized$')


### PR DESCRIPTION
1. Refactor webdriver cases for 06_grouped_rows.feature because of some data structure changed.

2. Add webdriver cases and make them as "work in progress" for "custom loading indicator", "default loading indicator" and other cases for lazily loaded in grouping column.