### PR TITLE
Finish WebDriver test cases for "Default Loading Indicator"

### DIFF
--- a/python-webdriver-tests/features/06_grouped_rows.feature
+++ b/python-webdriver-tests/features/06_grouped_rows.feature
@@ -263,7 +263,7 @@ Feature: Indicators for expanding and collapsing grouped rows
 #    Then There should be 2 sections loaded
 
 
-  @complete
+  @wip
   Scenario: The default loading indicator should display when partial load grouped loans
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
@@ -273,16 +273,16 @@ Feature: Indicators for expanding and collapsing grouped rows
     When Customer drags scroll bar by offset 40 with 1 times
     Then The default loading indicator should display on 15 items
 
-  @complete
-  Scenario: The default loading indicator should display when partial load children loans
-    Given I have the following partial loaded grouped data in MounteBank:
-      | groupName                                         | id | Beginning DR (Base) |
-      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
-    And Presenting "grouping column present partial loaded children"
-    And Click "expand" for the 0 row
-    And Stop mountebank
-    When Customer drags scroll bar by offset 20 with 1 times
-    Then The default loading indicator should display on 15 items
+#  @complete
+#  Scenario: The default loading indicator should display when partial load children loans
+#    Given I have the following partial loaded grouped data in MounteBank:
+#      | groupName                                         | id | Beginning DR (Base) |
+#      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+#    And Presenting "grouping column present partial loaded children"
+#    And Click "expand" for the 0 row
+#    And Stop mountebank
+#    When Customer drags scroll bar by offset 20 with 1 times
+#    Then The default loading indicator should display on 15 items
 
   @complete
   Scenario: The custom loading indicator should display when partial load grouped loans
@@ -291,7 +291,7 @@ Feature: Indicators for expanding and collapsing grouped rows
     And Click "expand" for the 1 row
     Then The custom loading indicator should display on 15 items
 
-  @complete
+  @wip
   Scenario: The default loading indicator should display when partial load children loans
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |

--- a/python-webdriver-tests/features/06_grouped_rows.feature
+++ b/python-webdriver-tests/features/06_grouped_rows.feature
@@ -84,10 +84,10 @@ Feature: Indicators for expanding and collapsing grouped rows
   Scenario: Expand grouped row with partial loaded children loans
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
-      | accountSection[20]-accountType[15]-accountCode[4] | f  | s                   |
+      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
     And Presenting "grouping column present partial loaded children"
+    And There should be 1 sections loaded
     When Click "expand" for the 0 row
-    Then There should be 2 sections loaded
 
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
@@ -98,12 +98,12 @@ Feature: Indicators for expanding and collapsing grouped rows
     Then There should be 3 sections loaded
 
     Given I have the following partial loaded grouped data in MounteBank:
-      | groupName                                         | id | Beginning DR (Base) |
-      | accountSection[20]-accountType[15]-accountCode[4] | f  | s                   |
+      | groupName                                          | id | Beginning DR (Base) |
+      | accountSection[20]-accountType[15]-accountCode[15] | f  | s                   |
     And Presenting "grouping column present partial loaded children"
     And Click "expand" for the 0 row
     And Click "expand" for the 1 row
-    When Customer drags scroll bar by offset 60 with 1 times
+    When Customer drags scroll bar by offset 20 with 1 times
     Then There should be 4 sections loaded
 
   @complete
@@ -223,7 +223,7 @@ Feature: Indicators for expanding and collapsing grouped rows
     When Click "collapse" for row "group2"
     Then The "GroupingColumn" column width should be 149 pixel
 
-  @wip
+  @complete
   Scenario: Expand grouped row with partial loaded
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
@@ -235,36 +235,45 @@ Feature: Indicators for expanding and collapsing grouped rows
       | groupName                                         | id | Beginning DR (Base) |
       | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
     And Presenting "grouping column present partial loaded children"
-    When Customer drags scroll bar by offset 60 with 2 times
+    When Customer drags scroll bar by offset 50 with 2 times
     Then There should be 3 sections loaded
 
-    Given I have the following partial loaded grouped data in MounteBank:
-      | groupName                                         | id | Beginning DR (Base) |
-      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
-    And Presenting "grouping column present partial loaded children"
-    When Click "expand" for the 0 row
-    Then There should be 2 sections loaded
+#    Given I have the following partial loaded grouped data in MounteBank:
+#      | groupName                                         | id | Beginning DR (Base) |
+#      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+#    And Presenting "grouping column present partial loaded children"
+#    When Click "expand" for the 0 row
+#    Then There should be 2 sections loaded
+#
+#    Given I have the following partial loaded grouped data in MounteBank:
+#      | groupName                                         | id | Beginning DR (Base) |
+#      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+#    And Presenting "grouping column present partial loaded children"
+#    And Click "expand" for the 0 row
+#    When Customer drags scroll bar by offset 20 with 1 times
+#    Then There should be 3 sections loaded
+#
+#    Given I have the following partial loaded grouped data in MounteBank:
+#      | groupName                                         | id | Beginning DR (Base) |
+#      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
+#    And Presenting "grouping column present partial loaded children"
+#    And Click "expand" for the 0 row
+#    When Click "collapse" for the 0 row
+#    And Click "expand" for the 0 row
+#    Then There should be 2 sections loaded
 
-    Given I have the following partial loaded grouped data in MounteBank:
-      | groupName                                         | id | Beginning DR (Base) |
-      | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
-    And Presenting "grouping column present partial loaded children"
-    And Click "expand" for the 0 row
-    When Customer drags scroll bar by offset 60 with 1 times
-    Then There should be 3 sections loaded
 
-
-  @wip
+  @complete
   Scenario: The default loading indicator should display when partial load grouped loans
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
       | accountSection[30]-accountType[15]-accountCode[4] | f  | s                   |
     And Presenting "grouping column present partial loaded children"
     And Stop mountebank
-    When Customer drags scroll bar by offset 60 with 1 times
+    When Customer drags scroll bar by offset 40 with 1 times
     Then The default loading indicator should display on 15 items
 
-  @wip
+  @complete
   Scenario: The default loading indicator should display when partial load children loans
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
@@ -275,14 +284,14 @@ Feature: Indicators for expanding and collapsing grouped rows
     When Customer drags scroll bar by offset 20 with 1 times
     Then The default loading indicator should display on 15 items
 
-  @wip
+  @complete
   Scenario: The custom loading indicator should display when partial load grouped loans
     Given Presenting "grouping column with pluggable loading indicator"
     When Click "expand" for the 0 row
     And Click "expand" for the 1 row
     Then The custom loading indicator should display on 15 items
 
-  @wip
+  @complete
   Scenario: The default loading indicator should display when partial load children loans
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                         | id | Beginning DR (Base) |
@@ -318,72 +327,177 @@ Feature: Indicators for expanding and collapsing grouped rows
 
 
   @wip
-  Scenario: The children rows should be sorted by single column
-    Given I have the following grouped loans in MounteBank:
-      | groupName | first | second |
-      | group1    | f1    | s1     |
-      | group2    | f2    | s2     |
-      | group3    | f3    | s3     |
-      | group4    | f4    | s4     |
-      | group5    | f5    | s5     |
-    When Presenting "grouping column present grouped loans"
+  Scenario: The children rows should be sorted by single column in completely loaded data
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                       | id | Beginning DR (Base) |
+      | accountSection[1]-accountType[2]-accountCode[4] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click "expand" for the 0 row
+    And Click "expand" for the 1 row
+    And I see grouped rows:
+      | indicator | groupName | Id     |
+      | -         |           | f1     |
+      | -         |           | f1-1   |
+      |           |           | f1-1-1 |
+      |           |           | f1-1-2 |
+      |           |           | f1-1-3 |
+      |           |           | f1-1-4 |
+    And Click to sort as "ASC" for column "Id"
+    When Click to sort as "DESC" for column "Id"
     Then I see grouped rows:
-      | indicator | groupName | first | second |
-      | +         | group1    | f1    | s1     |
-      | +         | group2    | f2    | s2     |
-      | +         | group3    | f3    | s3     |
-      | +         | group4    | f4    | s4     |
-      | +         | group5    | f5    | s5     |
-    When Click "expand" for row "row_parent"
+      | indicator | groupName | Id     |
+      | -         |           | f1     |
+      | -         |           | f1-1   |
+      |           |           | f1-1-4 |
+      |           |           | f1-1-3 |
+      |           |           | f1-1-2 |
+      |           |           | f1-1-1 |
+    And The "Id" column sort indicator should be "desc"
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                       | id | Beginning DR (Base) |
+      | accountSection[1]-accountType[2]-accountCode[2] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click "expand" for the 0 row
+    And Click "expand" for the 2 row
+    And Click to sort as "ASC" for column "Id"
+    And Click to sort as "DESC" for column "Id"
+    When Click "expand" for the 1 row
     Then I see grouped rows:
-      | indicator | groupName   | first | second |
-      | -         | group1      | f1    | s1     |
-      | +         | group1-chd1 | f1-1  | s1-1   |
-      | +         | group1-chd2 | f1-2  | s1-2   |
-      | +         | group2      | f2    | s2     |
-      | +         | group3      | f3    | s3     |
-      | +         | group4      | f4    | s4     |
-      | +         | group5      | f5    | s5     |
-    When Click "expand" for row "group1-chd1"
-    When Click "expand" for row "group1-chd2"
+      | indicator | groupName | Id     |
+      | -         |           | f1     |
+      | -         |           | f1-1   |
+      |           |           | f1-1-2 |
+      |           |           | f1-1-1 |
+      | -         |           | f1-2   |
+      |           |           | f1-2-2 |
+      |           |           | f1-2-1 |
+    And The "Id" column sort indicator should be "desc"
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                       | id | Beginning DR (Base) |
+      | accountSection[1]-accountType[2]-accountCode[2] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click to sort as "ASC" for column "Id"
+    And Click to sort as "DESC" for column "Id"
+    When Click "expand" for the 0 row
+    And Click "expand" for the 2 row
+    And Click "expand" for the 1 row
     Then I see grouped rows:
-      | indicator | groupName        | first  | second |
-      | -         | group1           | f1     | s1     |
-      | -         | group1-chd1      | f1-1   | s1-1   |
-      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1 |
-      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2 |
-      | -         | group1-chd2      | f1-2   | s1-2   |
-      |           | group1-chd2-chd1 | f1-2-1 | s1-2-1 |
-      |           | group1-chd2-chd2 | f1-2-2 | s1-2-2 |
-      | +         | group2           | f2     | s2     |
-      | +         | group3           | f3     | s3     |
-      | +         | group4           | f4     | s4     |
-      | +         | group5           | f5     | s5     |
-    When Click to sort as "ASC" for column "first"
+      | indicator | groupName | Id     |
+      | -         |           | f1     |
+      | -         |           | f1-1   |
+      |           |           | f1-1-2 |
+      |           |           | f1-1-1 |
+      | -         |           | f1-2   |
+      |           |           | f1-2-2 |
+      |           |           | f1-2-1 |
+    And The "Id" column sort indicator should be "desc"
+
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                       | id | Beginning DR (Base) |
+      | accountSection[1]-accountType[2]-accountCode[2] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    When Click "expand" for the 0 row
+    And Click "expand" for the 2 row
+    And Click "expand" for the 1 row
+    And Click to sort as "ASC" for column "Id"
+    When Click to sort as "DESC" for column "Id"
     Then I see grouped rows:
-      | indicator | groupName        | first  | second |
-      | -         | group1           | f1     | s1     |
-      | -         | group1-chd1      | f1-1   | s1-1   |
-      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1 |
-      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2 |
-      | -         | group1-chd2      | f1-2   | s1-2   |
-      |           | group1-chd2-chd1 | f1-2-1 | s1-2-1 |
-      |           | group1-chd2-chd2 | f1-2-2 | s1-2-2 |
-      | +         | group2           | f2     | s2     |
-      | +         | group3           | f3     | s3     |
-      | +         | group4           | f4     | s4     |
-      | +         | group5           | f5     | s5     |
-    When Click to sort as "DESC" for column "first"
+      | indicator | groupName | Id     |
+      | -         |           | f1     |
+      | -         |           | f1-1   |
+      |           |           | f1-1-2 |
+      |           |           | f1-1-1 |
+      | -         |           | f1-2   |
+      |           |           | f1-2-2 |
+      |           |           | f1-2-1 |
+    And The "Id" column sort indicator should be "desc"
+
+  @wip
+  Scenario: The children rows should be sorted by single column in lazily loaded data
+    Given I have the following partial loaded grouped data in MounteBank:
+      | groupName                                        | id | Beginning DR (Base) |
+      | accountSection[1]-accountType[1]-accountCode[10] | f  | s                   |
+    And Presenting "grouping column present partial loaded children"
+    And Click "expand" for the 0 row
+    And Click "expand" for the 1 row
+    And Customer drags scroll bar by offset 50 with 1 times
     Then I see grouped rows:
-      | indicator | groupName        | first  | second |
-      | -         | group1           | f1     | s1     |
-      | -         | group1-chd1      | f1-1   | s1-1   |
-      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2 |
-      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1 |
-      | -         | group1-chd2      | f1-2   | s1-2   |
-      |           | group1-chd2-chd1 | f1-2-2 | s1-2-2 |
-      |           | group1-chd2-chd2 | f1-2-1 | s1-2-1 |
-      | +         | group2           | f2     | s2     |
-      | +         | group3           | f3     | s3     |
-      | +         | group4           | f4     | s4     |
-      | +         | group5           | f5     | s5     |
+      | indicator | groupName | Id      |
+      |           |           | f1-1-6  |
+      |           |           | f1-1-7  |
+      |           |           | f1-1-8  |
+      |           |           | f1-1-9  |
+      |           |           | f1-1-10 |
+      |           |           | f1-1-4  |
+      |           |           | f1-1-5  |
+
+#    Given I have the following grouped loans in MounteBank:
+#      | groupName | first | second |
+#      | group1    | f1    | s1     |
+#      | group2    | f2    | s2     |
+#      | group3    | f3    | s3     |
+#      | group4    | f4    | s4     |
+#      | group5    | f5    | s5     |
+#    When Presenting "grouping column present grouped loans"
+#    Then I see grouped rows:
+#      | indicator | groupName | first | second |
+#      | +         | group1    | f1    | s1     |
+#      | +         | group2    | f2    | s2     |
+#      | +         | group3    | f3    | s3     |
+#      | +         | group4    | f4    | s4     |
+#      | +         | group5    | f5    | s5     |
+#    When Click "expand" for row "row_parent"
+#    Then I see grouped rows:
+#      | indicator | groupName   | first | second |
+#      | -         | group1      | f1    | s1     |
+#      | +         | group1-chd1 | f1-1  | s1-1   |
+#      | +         | group1-chd2 | f1-2  | s1-2   |
+#      | +         | group2      | f2    | s2     |
+#      | +         | group3      | f3    | s3     |
+#      | +         | group4      | f4    | s4     |
+#      | +         | group5      | f5    | s5     |
+#    When Click "expand" for row "group1-chd1"
+#    When Click "expand" for row "group1-chd2"
+#    Then I see grouped rows:
+#      | indicator | groupName        | first  | second |
+#      | -         | group1           | f1     | s1     |
+#      | -         | group1-chd1      | f1-1   | s1-1   |
+#      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1 |
+#      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2 |
+#      | -         | group1-chd2      | f1-2   | s1-2   |
+#      |           | group1-chd2-chd1 | f1-2-1 | s1-2-1 |
+#      |           | group1-chd2-chd2 | f1-2-2 | s1-2-2 |
+#      | +         | group2           | f2     | s2     |
+#      | +         | group3           | f3     | s3     |
+#      | +         | group4           | f4     | s4     |
+#      | +         | group5           | f5     | s5     |
+#    When Click to sort as "ASC" for column "first"
+#    Then I see grouped rows:
+#      | indicator | groupName        | first  | second |
+#      | -         | group1           | f1     | s1     |
+#      | -         | group1-chd1      | f1-1   | s1-1   |
+#      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1 |
+#      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2 |
+#      | -         | group1-chd2      | f1-2   | s1-2   |
+#      |           | group1-chd2-chd1 | f1-2-1 | s1-2-1 |
+#      |           | group1-chd2-chd2 | f1-2-2 | s1-2-2 |
+#      | +         | group2           | f2     | s2     |
+#      | +         | group3           | f3     | s3     |
+#      | +         | group4           | f4     | s4     |
+#      | +         | group5           | f5     | s5     |
+#    When Click to sort as "DESC" for column "first"
+#    Then I see grouped rows:
+#      | indicator | groupName        | first  | second |
+#      | -         | group1           | f1     | s1     |
+#      | -         | group1-chd1      | f1-1   | s1-1   |
+#      |           | group1-chd1-chd2 | f1-1-2 | s1-1-2 |
+#      |           | group1-chd1-chd1 | f1-1-1 | s1-1-1 |
+#      | -         | group1-chd2      | f1-2   | s1-2   |
+#      |           | group1-chd2-chd1 | f1-2-2 | s1-2-2 |
+#      |           | group1-chd2-chd2 | f1-2-1 | s1-2-1 |
+#      | +         | group2           | f2     | s2     |
+#      | +         | group3           | f3     | s3     |
+#      | +         | group4           | f4     | s4     |
+#      | +         | group5           | f5     | s5     |

--- a/python-webdriver-tests/features/basic_opr_module.py
+++ b/python-webdriver-tests/features/basic_opr_module.py
@@ -4,6 +4,9 @@ __author__ = 'Liang Zhen'
 from selenium.webdriver import ActionChains
 import time
 import os
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
 
 
 def drag_scroll_by_css(browser, offsetx, offsety):
@@ -23,11 +26,19 @@ def wait_for_elem(browser, script, timeout=20):
     return elems
 
 
+def wait_element_clickable(browser, css):
+    WebDriverWait(browser, 30).until(
+        EC.element_to_be_clickable((By.CSS_SELECTOR, css)))
+
+
 def drag_scroll_by_css_with_times(browser, offsety, times):
     start = time.time()
     css = "div.antiscroll-scrollbar.antiscroll-scrollbar-vertical"
+    wait_element_clickable(browser, css)
+
     while time.time() - start < 15:
         drag_scroll_by_css(browser, 0, offsety)
+        wait_element_clickable(browser, css)
         eles = browser.find_elements_by_css_selector(css)
         value = int(eles[0].get_attribute("style").split("top: ")[1].split("px")[0].split(".")[0])
         if value > int(offsety) * int(times):


### PR DESCRIPTION
1. Modify WebDriver test cases "Sorted by Single Column for Grouping Rows" and mark as "Working in Progress".
2. Update "Drag Scroll Bar" method because the scroll bar cannot be clickable immediately if when section is loading.
3. Finish WebDriver test cases for "Default Loading Indicator"