### PR TITLE
Add a time delay for webdriver test

### DIFF
--- a/app/controllers/lazy-loaded-loans.js
+++ b/app/controllers/lazy-loaded-loans.js
@@ -71,7 +71,6 @@ export default Ember.Controller.extend({
     },
 
     sortAction: function(sortCondition) {
-      console.log(sortCondition.get('sortName'), sortCondition.get('sortDirect'));
       this.set('sortName', sortCondition.get('sortName'));
       this.set('sortDirect', sortCondition.get('sortDirect'));
     }

--- a/python-webdriver-tests/features/steps.py
+++ b/python-webdriver-tests/features/steps.py
@@ -544,6 +544,7 @@ def start_mb(step):
 @step('The default loading indicator should display on (\d+) items$')
 def check_default_loading_indicator(step, num):
     with AssertContextManager(step):
+        time.sleep(0.01)
         indicator = world.browser.execute_script("return $('.row-loading-indicator.loading')")
         assert_true(step, len(indicator) == int(num))
         bo.start_mb()


### PR DESCRIPTION
This PR will be fix the webdriver problem of capturing loading indicator which need a small time delay. And it will merge immediately for "regular/command sort" on ember-table. If any problems, please let me know.