### PR TITLE
Refactor group row

### DIFF
--- a/app/adapters/chunked-group.js
+++ b/app/adapters/chunked-group.js
@@ -9,20 +9,15 @@ export default DS.RESTAdapter.extend({
   findQuery: function(store, type, options) {
     var query = options || {};
     var urlSections = [];
-    var groupingMetadata = options.groupingMetadata || [];
-    for (var i=0; i< groupingMetadata.length; i++){
-      var groupingKey = groupingMetadata[i].id;
-      if(groupingKey){
-        urlSections.push(Ember.String.pluralize(groupingKey));
-      }
-      if(query[groupingKey]){
-        urlSections.push(query[groupingKey]);
-        delete query[groupingKey];
-      } else {
-        break;
-      }
+    var groupQuery = options.groupQuery;
+    groupQuery.upperGroupings.forEach(function(x) {
+      urlSections.push(x[0] + "s");
+      urlSections.push(Ember.get(x[1], 'id'));
+    });
+    if (groupQuery.key) {
+      urlSections.push(groupQuery.key + "s");
     }
-    delete options.groupingMetadata;
+    delete query.groupQuery;
     var baseUrl = this.buildURL(type.typeKey, options, null, 'findQuery');
     urlSections.insertAt(0, baseUrl);
     return this.ajax(urlSections.join('/'), 'GET', {data: query});

--- a/app/mixins/chunked-group-data-mixin.js
+++ b/app/mixins/chunked-group-data-mixin.js
@@ -8,15 +8,17 @@ export default Ember.Mixin.create({
     var self = this;
     var groupingMetadata = this.get('groupingMetadata');
     return LazyGroupRowArray.create({
-      loadChildren: function (chunkIndex, parentQuery, sortingColumns) {
-        var parameters = {};
-        Ember.setProperties(parameters, parentQuery);
+      loadChildren: function (chunkIndex, sortingColumns, groupQuery) {
+        var parameters = {
+          section: chunkIndex + 1,
+          groupQuery: groupQuery
+        };
         parameters.section = chunkIndex + 1;
-        if (self.isLastLevel(parentQuery)) {
+
+        if (self.isLastLevel(groupQuery.key)) {
           var sortQuery = self.makeSortQuery(sortingColumns);
           Ember.setProperties(parameters, sortQuery);
         }
-        parameters.groupingMetadata = groupingMetadata;
         return self.store.find('chunked-group', parameters).then(function (result) {
           var meta = self.store.metadataFor('chunked-group');
           return {
@@ -38,10 +40,10 @@ export default Ember.Mixin.create({
     }
   },
 
-  isLastLevel: function (parentQuery) {
+  isLastLevel: function (groupKey) {
     var groupingMetadata = this.get('groupingMetadata');
-    var lastLevelQueryKey = groupingMetadata[groupingMetadata.length - 2].id;
-    return parentQuery.hasOwnProperty(lastLevelQueryKey);
+    var lastLevelQueryKey = groupingMetadata[groupingMetadata.length - 1].id;
+    return groupKey === lastLevelQueryKey;
   },
 
   groupingMetadata: [{id: 'accountSection'}, {id: 'accountType'}, {id: 'accountCode'}]

--- a/app/routes/grand-total-row.js
+++ b/app/routes/grand-total-row.js
@@ -1,17 +1,15 @@
 import Ember from 'ember';
-import GrandTotalRow from 'ember-table/models/grand-total-row';
 
 export default Ember.Route.extend({
   model: function () {
     var self = this;
     var groupingMetadata = [{id: 'accountSection'}, {id: 'accountType'}, {id: 'accountCode'}];
-    var tableContent = GrandTotalRow.create({
-      loadChildren: function (chunkIndex, parentQuery) {
+    var tableContent = Ember.Object.create({
+      loadChildren: function (chunkIndex, sortingColumns, groupQuery) {
         var query = {
           section: chunkIndex + 1,
-          groupingMetadata: groupingMetadata
+          groupQuery: groupQuery
         };
-        Ember.setProperties(query, parentQuery);
         return self.store.find('chunked-group', query).then(function (result) {
           var meta = self.store.metadataFor('chunked-group');
           return {
@@ -21,11 +19,6 @@ export default Ember.Route.extend({
               chunkSize: meta.page_size
             }
           };
-        });
-      },
-      loadGrandTotal: function () {
-        return self.store.find('chunked-group', {section: 1}).then(function (result) {
-          return result.get('firstObject');
         });
       },
       groupingMetadata: groupingMetadata,

--- a/python-webdriver-tests/features/06_grouped_rows.feature
+++ b/python-webdriver-tests/features/06_grouped_rows.feature
@@ -604,6 +604,7 @@ Feature: Indicators for expanding and collapsing grouped rows
       |           | 10105     | 10105 |
     Then There should be 4 sections loaded
 
+    #TODO: use visible row order instead of dom orders
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                        | id   | Beginning DR (Base) |
       | accountSection[1]-accountType[2]-accountCode[20] | [20] | [20]                |
@@ -611,7 +612,7 @@ Feature: Indicators for expanding and collapsing grouped rows
     And Click "expand" for the 0 row
     And Click "expand" for the 2 row
     And Click "expand" for the 1 row
-    And Customer drags scroll bar by offset 1000 with 1 times and wait loading section
+    And Customer drags scroll bar by offset 60 with 2 times and wait loading section
     And Click to sort as "ASC" for column "Id"
     When Click to sort as "DESC" for column "Id"
     Then I see grouped rows:
@@ -620,7 +621,10 @@ Feature: Indicators for expanding and collapsing grouped rows
       | -         | 102       | 102   |
       |           | 10220     | 10220 |
       |           | 10219     | 10219 |
-    Then There should be 6 sections loaded
+      |           | 10104     | 10104 |
+      |           | 10103     | 10103 |
+      |           | 10102     | 10102 |
+    Then There should be 7 sections loaded
 
     Given I have the following partial loaded grouped data in MounteBank:
       | groupName                                        | id | Beginning DR (Base) |

--- a/python-webdriver-tests/features/07_multi_column_sort.feature
+++ b/python-webdriver-tests/features/07_multi_column_sort.feature
@@ -901,7 +901,7 @@ Feature: Multi-Column Sorting
     And The "status" column sort order is "1"
     And The "Use" column sort order is "2"
 
-  @complete
+  @complete1
   Scenario: Data sorted on a multiple columns regular click on existing column toggles direction for that column then remove column from sort with grouped row fully load
     Given Prepare the grid with no existing sorting column for "fully load":
       | groupName        | id     | activity | status | use     | sector  | isGroupRow |

--- a/python-webdriver-tests/features/07_multi_column_sort.feature
+++ b/python-webdriver-tests/features/07_multi_column_sort.feature
@@ -448,7 +448,7 @@ Feature: Multi-Column Sorting
       |           | 10103     | 10103 | s1-1-3              |
       |           | 10105     | 10105 | s1-1-5              |
     And The "Activity" column sort indicator should be "none"
-    Then There should be 5 sections loaded
+    Then There should be 6 sections loaded
 
   @complete
   Scenario: Data sorted on a single column regular click on different column changes sort to that column with no grouped row
@@ -901,7 +901,7 @@ Feature: Multi-Column Sorting
     And The "status" column sort order is "1"
     And The "Use" column sort order is "2"
 
-  @complete1
+  @complete
   Scenario: Data sorted on a multiple columns regular click on existing column toggles direction for that column then remove column from sort with grouped row fully load
     Given Prepare the grid with no existing sorting column for "fully load":
       | groupName        | id     | activity | status | use     | sector  | isGroupRow |

--- a/tests/unit/adapters/chunked-group-test.js
+++ b/tests/unit/adapters/chunked-group-test.js
@@ -27,13 +27,11 @@ moduleFor('adapter:chunked-group', 'Unit | Adapter | chunked group', {
   }
 });
 
-// Replace this with your real tests.
 test('only one level', function(assert) {
   ajaxResponse({chunkedGroups: [{id: 1}]});
   this.subject();
   var params = {
-    groupingMetadata: [{id: 'accountSection'}, {id: 'accountType'}],
-    accountSection: 1
+    groupQuery: {key: "accountType", upperGroupings: [["accountSection", {id: 1}]]}
   };
   Ember.run(function () {
     store.find('chunkedGroup', params).then(function () {
@@ -46,9 +44,7 @@ test('three level data', function(assert) {
   ajaxResponse({chunkedGroups: [{id: 1}]});
   this.subject();
   var params = {
-    accountSection: 2,
-    accountType: 3,
-    groupingMetadata: [{id: 'accountSection'}, {id: 'accountType'}, {id: 'accountCode'}]
+    groupQuery: {key: "accountCode", upperGroupings: [["accountSection", {id: 2}], ["accountType", {id: 3}]]}
   };
   Ember.run(function () {
     store.find('chunkedGroup', params).then(function () {


### PR DESCRIPTION
parentQuery is not provided as parameter in loadingChildren.
- parentQuery use content.id for upper groupings, which is too rigid
- use grouping which contains group key and upper groupings