### PR TITLE
Add WebDriver test cases for grouper sort with partial loaded data.

### DIFF
--- a/app/mixins/account-columns-mixin.js
+++ b/app/mixins/account-columns-mixin.js
@@ -4,7 +4,7 @@ import ColumnDefinition from 'ember-table/models/column-definition';
 export default Ember.Mixin.create({
   columns: function () {
     var columnTitleAndNames = [
-      ["Id", "id"],
+      ["Id", "id", "decimal"],
       ["Beginning DR (Base)", "beginningDr"],
       ["Beginning CR (Base)", "beginningCr"],
       ["Net Beginning (Base)", "netBeginning"],
@@ -19,18 +19,9 @@ export default Ember.Mixin.create({
       return ColumnDefinition.create({
         headerCellName: titleAndName[0],
         contentPath: titleAndName[1],
+        dataType: titleAndName[2],
         getCellContent: function (row) {
           return Ember.get(row, titleAndName[1]);
-        },
-        sortBy: function(prev, next){
-          var prevName = prev.get(titleAndName[1]);
-          var nextName = next.get(titleAndName[1]);
-          if(typeof prevName === 'number') {
-            return prevName - nextName;
-          }
-          else {
-            return (prevName < nextName) ? -1 : (prevName > nextName) ? 1 : 0;
-          }
         }
       });
     });

--- a/app/templates/sort-by-grouper.hbs
+++ b/app/templates/sort-by-grouper.hbs
@@ -5,7 +5,7 @@
 {{/each}}
 </div>
 
-<div class="lazy-loaded-table-container" style="height:300px">
+<div class="lazy-loaded-table-container" style="height:240px">
   {{ember-table
   hasFooter=false
   enableContentSelection=true

--- a/python-webdriver-tests/features/08_sort_grouper.feature
+++ b/python-webdriver-tests/features/08_sort_grouper.feature
@@ -126,7 +126,7 @@ Feature: Multi-Column Sorting
       | +         | 202       | 202   |
     When Click grouper "accountSection" to sort as "DESC"
     And Click grouper "accountType" to sort as "DESC"
-    And I see grouped rows:
+    Then I see grouped rows:
       | indicator | groupName | Id    |
       | -         | 2         | 2     |
       | +         | 202       | 202   |
@@ -248,14 +248,22 @@ Feature: Multi-Column Sorting
       | +         | 201       | 201   |
       | +         | 1         | 1     |
 
-  @wip
+  @complete
   Scenario: Sort by grouper first level with partial loaded data
     Given Prepare the grid with no existing sorting column for "grouper":
       | groupName                                          | id |
       | accountSection[21]-accountType[21]-accountCode[21] |    |
     When Click grouper "accountSection" to sort as "ASC"
+    And I see grouped rows:
+      | indicator | groupName | Id |
+      | +         | 1         | 1  |
+      | +         | 10        | 10 |
+      | +         | 11        | 11 |
+      | +         | 12        | 12 |
+      | +         | 13        | 13 |
+      | +         | 14        | 14 |
     And Click grouper "accountSection" to sort as "unsort"
-    Then There should be 8 sections loaded
+    Then There should be 4 sections loaded
     And I see grouped rows:
       | indicator | groupName | Id |
       | +         | 1         | 1  |
@@ -267,7 +275,7 @@ Feature: Multi-Column Sorting
 
 #  The scenario tracks defect https://hedgeserv.leankit.com/Boards/View/200742377/237591318
   @wip
-  Scenario: Sort by grouper by first and second level with partial load data
+  Scenario: Sort by grouper first and second level with partial loaded data
     Given Prepare the grid with no existing sorting column for "grouper":
       | groupName                                          | id |
       | accountSection[21]-accountType[21]-accountCode[11] |    |
@@ -276,17 +284,17 @@ Feature: Multi-Column Sorting
     And Click grouper "accountSection" to sort as "ASC"
     And There should be 5 sections loaded
     And Click grouper "accountSection" to sort as "unsort"
-    And There should be 8 sections loaded
+    Then There should be 8 sections loaded
 
-  @wip
+  @complete
   Scenario: Check the expanded status should be kept after sort grouper
     Given Prepare the grid with no existing sorting column for "grouper":
-      | groupName                                          | id |
-      | accountSection[21]-accountType[21]-accountCode[11] |    |
+      | groupName                                         | id |
+      | accountSection[21]-accountType[5]-accountCode[11] |    |
     When Click "expand" for row "1"
     And Click "expand" for row "101"
-    And Click grouper "accountSection" to sort as "DESC"
-    And Customer drags scroll bar by offset 50 with 4 times and wait loading section
+    And Click grouper "accountSection" to sort as "ASC"
+    And Click grouper "accountSection" to sort as "unsort"
     Then I see grouped rows:
       | indicator | groupName | Id    |
       | -         | 1         | 1     |
@@ -296,7 +304,108 @@ Feature: Multi-Column Sorting
       |           | 10103     | 10103 |
       |           | 10104     | 10104 |
       |           | 10105     | 10105 |
-      |           | 10106     | 10106 |
+
+  @complete
+  Scenario: Sort by grouper second and third level with partial loaded data
+    Given Prepare the grid with no existing sorting column for "grouper":
+      | groupName                                          | id |
+      | accountSection[11]-accountType[11]-accountCode[11] |    |
+    When Click grouper "accountType" to sort as "DESC"
+    And Click grouper "accountCode" to sort as "DESC"
+    And Click "expand" for row "1"
+    And Click "expand" for row "111"
+    Then There should be 3 sections loaded
+    And I see grouped rows:
+      | indicator | groupName | Id    |
+      | -         | 1         | 1     |
+      | -         | 111       | 111   |
+      |           | 11111     | 11111 |
+      |           | 11110     | 11110 |
+      |           | 11109     | 11109 |
+      |           | 11108     | 11108 |
+
+  @complete
+  Scenario: Sort by grouper and column with partial loaded data
+    Given Prepare the grid with no existing sorting column for "grouper":
+      | groupName                                          | id |
+      | accountSection[11]-accountType[11]-accountCode[11] |    |
+    When Click grouper "accountType" to sort as "DESC"
+    And Click grouper "accountCode" to sort as "DESC"
+    And Click "expand" for row "1"
+    And Click "expand" for row "111"
+    And Click to sort as "ASC" for column "Id"
+    And I see grouped rows:
+      | indicator | groupName | Id    |
+      | -         | 1         | 1     |
+      | -         | 111       | 111   |
+      |           | 11111     | 11111 |
+      |           | 11110     | 11110 |
+      |           | 11109     | 11109 |
+      |           | 11108     | 11108 |
+
+    Given Prepare the grid with no existing sorting column for "grouper":
+      | groupName                                          | id   |
+      | accountSection[11]-accountType[11]-accountCode[11] | [11] |
+    When Click grouper "accountType" to sort as "DESC"
+    And Click "expand" for row "1"
+    And Click "expand" for row "111"
+    And Click to sort as "ASC" for column "Id"
+    And I see grouped rows:
+      | indicator | groupName | Id    |
+      | -         | 1         | 1     |
+      | -         | 111       | 111   |
+      |           | 11101     | 11101 |
+      |           | 11102     | 11102 |
+      |           | 11103     | 11103 |
+      |           | 11104     | 11104 |
+
+#    The scenario tracks defect https://hedgeserv.leankit.com/Boards/View/200742377/237591318
+#    Given Prepare the grid with no existing sorting column for "grouper":
+#      | groupName                                          | id   |
+#      | accountSection[21]-accountType[11]-accountCode[11] | [11] |
+#    When Click grouper "accountType" to sort as "DESC"
+#    And Click "expand" for row "1"
+#    And Click "expand" for row "111"
+#    And Click to sort as "ASC" for column "Id"
+#    And Click to sort as "DESC" for column "Id"
+#      | indicator | groupName | Id |
+#      | +         | 11        | 11 |
+#      | +         | 10        | 10 |
+#      | +         | 9         | 9  |
+#      | +         | 8         | 8  |
+#      | +         | 8         | 8  |
+#      | +         | 7         | 7  |
+#    Then There should be 6 sections loaded
+#    And The "Id" column sort indicator should be "desc"
+
+  @complete
+  Scenario: Remove the grouper sort with column sort
+    Given Prepare the grid with no existing sorting column for "grouper":
+      | groupName                                          | id   |
+      | accountSection[11]-accountType[11]-accountCode[11] | [11] |
+    And Click grouper "accountType" to sort as "ASC"
+    And Click to sort as "ASC" for column "Id"
+    And Click to sort as "DESC" for column "Id"
+    And Click "expand" for row "11"
+    And I see grouped rows:
+      | indicator | groupName | Id   |
+      | -         | 11        | 11   |
+      | +         | 1101      | 1101 |
+      | +         | 1102      | 1102 |
+      | +         | 1103      | 1103 |
+      | +         | 1104      | 1104 |
+      | +         | 1105      | 1105 |
+    When Click grouper "accountType" to sort as "unsort"
+    Then I see grouped rows:
+      | indicator | groupName | Id   |
+      | -         | 11        | 11   |
+      | +         | 1111      | 1111 |
+      | +         | 1110      | 1110 |
+      | +         | 1109      | 1109 |
+      | +         | 1108      | 1108 |
+      | +         | 1107      | 1107 |
+
+
 
 
 

--- a/python-webdriver-tests/features/terrain.py
+++ b/python-webdriver-tests/features/terrain.py
@@ -7,8 +7,7 @@ def setup_browser(scenario):
     driver_arguments = {'chrome_options': webdriver.ChromeOptions()}
     driver_arguments['chrome_options'].add_argument('--no-sandbox')
     world.browser = webdriver.Chrome(chrome_options=driver_arguments['chrome_options'])
-    # world.browser.set_window_size(1024, 768)
-    world.browser.set_window_size(1280, 1024)
+    world.browser.set_window_size(1024, 768)
 
 
 @after.each_scenario


### PR DESCRIPTION
Update the table height to fix the issue we met yesterday, only one section will be loaded in travis if we give the height with 300 but two sections in our local devices, because the table will display 11 records in local but 10 records in travis-ci.