### PR TITLE
Fix page scroll and enable affix menu.

### DIFF
--- a/app/components/feature-pages-nav.js
+++ b/app/components/feature-pages-nav.js
@@ -1,5 +1,49 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  tagName: 'nav'
+  afterRenderEvent: function () {
+    this.initAffixMenu();
+  },
+
+  initAffixMenu: function () {
+    if (this.$(".affix-menu").length > 0) {
+      var self = this;
+      Ember.run.later(function () {
+        var $sideBar = self.$();
+        $sideBar.affix({
+          offset: {
+            top: function () {
+              var offsetTop = $sideBar.offset().top;
+              return (this.top = offsetTop - 65);
+            },
+            bottom: function () {
+              var affixBottom = Ember.$(".footer").outerHeight(true) + Ember.$(".subfooter").outerHeight(true);
+              if (self.$(".footer-top").length > 0) {
+                affixBottom = affixBottom + self.$(".footer-top").outerHeight(true);
+              }
+              return (this.bottom = affixBottom + 50);
+            }
+          }
+        });
+      }, 100);
+    }
+  },
+
+  scrollSpy: function () {
+    if(this.$(".scrollspy").length>0) {
+      Ember.$("body").addClass("scroll-spy");
+      if(Ember.$(".fixed.header").length>0) {
+        Ember.$('body').scrollspy({
+          target: '.scrollspy',
+          offset: 85
+        });
+      } else {
+        Ember.$('body').scrollspy({
+          target: '.scrollspy',
+          offset: 20
+        });
+      }
+    }
+
+  }
 });

--- a/app/components/fixed-header.js
+++ b/app/components/fixed-header.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['header', 'fixed', 'clearfix'],
+  tagName: 'header',
+
+  afterRenderEvent: function() {
+    // Ignore '$ undefined warning'
+    /* jshint ignore:start */
+    var	headerTopHeight = this.$(".header-top").outerHeight();
+    var headerHeight = this.$().outerHeight();
+    Ember.$(window).scroll(function() {
+      if(($(this).scrollTop() > headerTopHeight+headerHeight) && ($(window).width() > 767)) {
+        $("body").addClass("fixed-header-on");
+        $(".header.fixed").addClass('animated object-visible fadeInDown');
+        if (!($(".header.transparent").length>0)) {
+          if ($(".banner:not(.header-top)").length>0) {
+            $(".banner").css("marginTop", (headerHeight)+"px");
+          } else if ($(".page-intro").length>0) {
+            $(".page-intro").css("marginTop", (headerHeight)+"px");
+          } else if ($(".page-top").length>0) {
+            $(".page-top").css("marginTop", (headerHeight)+"px");
+          } else {
+            $("section.main-container").css("marginTop", (headerHeight)+"px");
+          }
+        }
+      } else {
+        $("body").removeClass("fixed-header-on");
+        $("section.main-container").css("marginTop", (0)+"px");
+        $(".banner").css("marginTop", (0)+"px");
+        $(".page-intro").css("marginTop", (0)+"px");
+        $(".page-top").css("marginTop", (0)+"px");
+        $(".header.fixed").removeClass('animated object-visible fadeInDown');
+      }
+    });
+    /* jshint ignore:end */
+  }
+});

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,19 +1,4 @@
 <div class="page-wrapper">
-    <header class="header fixed clearfix">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-3">
-                    <div class="header-left clearfix">
-                        <div class="logo">
-                            <a href="/">
-                                <br>
-                                <img id="logo" src="images/logo.png" alt="iDea">
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
+  {{fixed-header}}
   {{outlet}}
 </div>

--- a/app/templates/components/feature-pages-nav.hbs
+++ b/app/templates/components/feature-pages-nav.hbs
@@ -1,7 +1,9 @@
-<ul class="nav nav-pills nav-stacked">
-  {{#each tables as |table| }}
-    {{#link-to table.link tagName='li' class=table.labelClass href=false}}
-      {{#link-to table.link }}{{table.name}}{{/link-to}}
-    {{/link-to}}
-  {{/each}}
-</ul>
+<nav class="affix-menu scrollspy">
+    <ul class="nav nav-pills nav-stacked">
+      {{#each tables as |table| }}
+        {{#link-to table.link tagName='li' class=table.labelClass href=false}}
+          {{#link-to table.link }}{{table.name}}{{/link-to}}
+        {{/link-to}}
+      {{/each}}
+    </ul>
+</nav>

--- a/app/templates/components/fixed-header.hbs
+++ b/app/templates/components/fixed-header.hbs
@@ -1,0 +1,14 @@
+<div class="container">
+    <div class="row">
+        <div class="col-md-3">
+            <div class="header-left clearfix">
+                <div class="logo">
+                    <a href="/">
+                        <br>
+                        <img id="logo" src="images/logo.png" alt="logo">
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/templates/features-show.hbs
+++ b/app/templates/features-show.hbs
@@ -5,12 +5,8 @@
           {{features-list features=features}}
           {{yield}}
         </div>
-        <aside class="col-md-3">
-            <div class="sidebar">
-                <nav class="affix-menu scrollspy">
-                  {{feature-pages-nav tables=tables }}
-                </nav>
-            </div>
+        <aside class="col-md-3 hidden-xs hidden-sm">
+          {{feature-pages-nav tables=tables }}
         </aside>
     </div>
 </div>

--- a/app/templates/features-show.hbs
+++ b/app/templates/features-show.hbs
@@ -1,12 +1,12 @@
-<div class="container main-container">
+<section class="container main-container">
     <div class="row">
         <div class="main col-md-9">
             <h2 class="page-title">{{title}}</h2>
           {{features-list features=features}}
           {{yield}}
         </div>
-        <aside class="col-md-3 hidden-xs hidden-sm">
+        <aside class="col-md-3">
           {{feature-pages-nav tables=tables }}
         </aside>
     </div>
-</div>
+</section>

--- a/lib/bootstrap-idea/vendor/js/template.js
+++ b/lib/bootstrap-idea/vendor/js/template.js
@@ -158,38 +158,6 @@
 			});
 		};
 
-		// Fixed header
-		//-----------------------------------------------
-		var	headerTopHeight = $(".header-top").outerHeight();
-		var headerHeight = $("header.header.fixed").outerHeight();
-		$(window).scroll(function() {
-			var hiddenBodyHeight = $('body').height() - $(window).height();
-			if (($(".header.fixed").length > 0)) {
-				if(($(this).scrollTop() > headerTopHeight+headerHeight) && ($(window).width() > 767) && (hiddenBodyHeight > $("header.header.fixed").outerHeight())) {
-					$("body").addClass("fixed-header-on");
-					$(".header.fixed").addClass('animated object-visible fadeInDown');
-					if (!($(".header.transparent").length>0)) {
-						if ($(".banner:not(.header-top)").length>0) {
-							$(".banner").css("marginTop", (headerHeight)+"px");
-						} else if ($(".page-intro").length>0) {
-							$(".page-intro").css("marginTop", (headerHeight)+"px");
-						} else if ($(".page-top").length>0) {
-							$(".page-top").css("marginTop", (headerHeight)+"px");
-						} else {
-							$("section.main-container").css("marginTop", (headerHeight)+"px");
-						}
-					}
-				} else {
-					$("body").removeClass("fixed-header-on");
-					$("section.main-container").css("marginTop", (0)+"px");
-					$(".banner").css("marginTop", (0)+"px");
-					$(".page-intro").css("marginTop", (0)+"px");
-					$(".page-top").css("marginTop", (0)+"px");
-					$(".header.fixed").removeClass('animated object-visible fadeInDown');
-				}
-			}
-		});
-
 		// Sharrre plugin
 		//-----------------------------------------------
 		if ($('#share').length>0) {

--- a/lib/bootstrap-idea/vendor/js/template.js
+++ b/lib/bootstrap-idea/vendor/js/template.js
@@ -187,7 +187,7 @@
 					$(".page-top").css("marginTop", (0)+"px");
 					$(".header.fixed").removeClass('animated object-visible fadeInDown');
 				}
-			};
+			}
 		});
 
 		// Sharrre plugin
@@ -485,28 +485,6 @@
 
 			});
 		}
-		if ($(".affix-menu").length>0) {
-			setTimeout(function () {
-				var $sideBar = $('.sidebar')
-
-				$sideBar.affix({
-					offset: {
-						top: function () {
-							var offsetTop      = $sideBar.offset().top
-							return (this.top = offsetTop - 65)
-						},
-						bottom: function () {
-							var affixBottom = $(".footer").outerHeight(true) + $(".subfooter").outerHeight(true)
-							if ($(".footer-top").length>0) {
-								affixBottom = affixBottom + $(".footer-top").outerHeight(true)
-							}
-							return (this.bottom = affixBottom+50)
-						}
-					}
-				})
-			}, 100)
-		}
-
 		//Smooth Scroll
 		//-----------------------------------------------
 		if ($(".smooth-scroll").length>0) {
@@ -539,22 +517,6 @@
 			}
 		}
 
-		//Scroll Spy
-		//-----------------------------------------------
-		if($(".scrollspy").length>0) {
-			$("body").addClass("scroll-spy");
-			if($(".fixed.header").length>0) {
-				$('body').scrollspy({
-					target: '.scrollspy',
-					offset: 85
-				});
-			} else {
-				$('body').scrollspy({
-					target: '.scrollspy',
-					offset: 20
-				});
-			}
-		}
 
 		//Scroll totop
 		//-----------------------------------------------


### PR DESCRIPTION
- Page will flicker when scroll up. Fixed by moving fixed header to a component, and register scroll event after component is rendered.
- Enable affix menu, so the feature pages navigation list will stay there when scroll up. 