### PR TITLE
Use view name instead of class and remove styling for 'group header block'

### DIFF
--- a/app/controllers/custom-group-indicator.js
+++ b/app/controllers/custom-group-indicator.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import ThreeColumnsMixin from '../mixins/three-columns-mixin';
 import TableContentMixin from '../mixins/table-content-mixin';
-import GroupedRowIndicatorWithLevel from './../views/grouped-row-indicator-with-level';
 import TableFeatures from '../mixins/features';
 
 export default Ember.Controller.extend(ThreeColumnsMixin, TableContentMixin, TableFeatures, {
-  indicatorView: GroupedRowIndicatorWithLevel,
+  indicatorViewName: 'grouped-row-indicator-with-level',
   title: 'Custom Group Indicator'
 });

--- a/app/controllers/grouped-row-loading-indicator.js
+++ b/app/controllers/grouped-row-loading-indicator.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import AccountColumnsMixin from '../mixins/account-columns-mixin';
 import TableContentMixin from '../mixins/table-content-mixin';
-import CustomRowLoadingIndicator from './../views/custom-row-loading-indicator';
 import TableFeatures from '../mixins/features';
 
 export default Ember.Controller.extend(AccountColumnsMixin, TableContentMixin, TableFeatures, {
-  rowLoadingIndicatorView: CustomRowLoadingIndicator,
+  rowLoadingIndicatorViewName: 'custom-row-loading-indicator',
   title: 'Row Loading Indicator'
 });

--- a/app/controllers/style-customization.js
+++ b/app/controllers/style-customization.js
@@ -38,24 +38,20 @@ export default Ember.Controller.extend(TableFeatures, TreeDataGridMixin, {
     });
     return [
       StylePart.create({
-        title: 'First Column',
+        title: 'First Inner Column',
         partName: 'firstColumnStyle'
       }),
       StylePart.create({
-        title: 'Inner Column',
+        title: 'All Inner Columns',
         partName: 'innerColumnStyle'
       }),
       StylePart.create({
-        title: 'Last Column',
+        title: 'Last Inner Column',
         partName: 'lastColumnStyle'
       }),
       StylePart.create({
         title: 'Grouping Cells',
         partName: 'cellStyle' //apply to grouping header cell only
-      }),
-      StylePart.create({
-        title: 'Group Block',
-        partName: 'groupStyle' //apply to all header cells
       })
     ];
   }),

--- a/app/controllers/style-customization.js
+++ b/app/controllers/style-customization.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 import TableFeatures from '../mixins/features';
 import TreeDataGridMixin from '../mixins/tree-data-grid';
-import GroupedRowIndicatorWithLevel from './../views/grouped-row-indicator-with-level';
-import CustomRowLoadingIndicator from './../views/custom-row-loading-indicator';
 
 export default Ember.Controller.extend(TableFeatures, TreeDataGridMixin, {
   tableContent: [],
@@ -95,19 +93,19 @@ export default Ember.Controller.extend(TableFeatures, TreeDataGridMixin, {
   groupIndicatorOptions: [
     {
       title: 'With Level',
-      id: GroupedRowIndicatorWithLevel
+      id: 'grouped-row-indicator-with-level'
     }
   ],
 
   groupIndicatorWidth: Ember.computed(function () {
-    var view = this.get('selectedGroupIndicatorView');
+    var view = this.get('selectedGroupIndicatorViewName');
     return view ? 25 : 10;
-  }).property('selectedGroupIndicatorView'),
+  }).property('selectedGroupIndicatorViewName'),
 
   loadingIndicatorOptions: [
     {
       title: 'Custom background',
-      id: CustomRowLoadingIndicator
+      id: 'custom-row-loading-indicator'
     }
   ]
 });

--- a/app/mixins/features.js
+++ b/app/mixins/features.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   _tables: [{
-    name: "Tree Data",
-    description: "sort group data by groupers and columns",
-    link: "treeData"
-  },{
     name: "Array Data",
     description: "this is a faster experience for the end user because of lazy loading.",
     link: "arrayData"
+  }, {
+    name: "Tree Data",
+    description: "sort group data by groupers and columns",
+    link: "treeData"
   }, {
     name: "Style Customization",
     description: '',

--- a/app/templates/custom-group-indicator.hbs
+++ b/app/templates/custom-group-indicator.hbs
@@ -4,7 +4,7 @@
 	  enableContentSelection=true
 	  content=tableContent
 	  columns=columns
-	  groupedRowIndicatorView=indicatorView
+	  groupedRowIndicatorViewName=indicatorViewName
     groupIndicatorWidth=25
     groupMeta=groupMeta
   }}

--- a/app/templates/grouped-row-loading-indicator.hbs
+++ b/app/templates/grouped-row-loading-indicator.hbs
@@ -8,7 +8,7 @@
   hasFooter=false
   enableContentSelection=true
   content=tableContent
-  rowLoadingIndicatorView=rowLoadingIndicatorView
+  rowLoadingIndicatorViewName=rowLoadingIndicatorViewName
   columns=columns
   groupMeta=groupMeta
   }}

--- a/app/templates/style-customization.hbs
+++ b/app/templates/style-customization.hbs
@@ -29,7 +29,7 @@
           content=groupIndicatorOptions
           optionValuePath="content.id"
           optionLabelPath="content.title"
-          value=selectedGroupIndicatorView
+          value=selectedGroupIndicatorViewName
           prompt="Please select a style"
         }}
     </div>
@@ -39,7 +39,7 @@
           content=loadingIndicatorOptions
           optionValuePath="content.id"
           optionLabelPath="content.title"
-          value=selectedRowLoadingIndicatorView
+          value=selectedRowLoadingIndicatorViewName
           prompt="Please select a style"
         }}
     </div>
@@ -53,8 +53,8 @@
   sortAction='sortAction'
   groupMeta=model
   sortIndicatorViewName=selectedSortIndicatorViewName
-  groupedRowIndicatorView=selectedGroupIndicatorView
+  groupedRowIndicatorViewName=selectedGroupIndicatorViewName
   groupIndicatorWidth=groupIndicatorWidth
-  rowLoadingIndicatorView=selectedRowLoadingIndicatorView
+  rowLoadingIndicatorViewName=selectedRowLoadingIndicatorViewName
   }}
 </div>


### PR DESCRIPTION
- Change to use view name after ember-table PR merged
- Removed styling for 'group header block', as this styling apply to invisible `group header block`, which will confuse most people. And we can use `inner-column cell` and `group cell` to style all cells.